### PR TITLE
change available crypto API call to use the correct API endpoint

### DIFF
--- a/fmpsdk/__init__.py
+++ b/fmpsdk/__init__.py
@@ -1606,7 +1606,7 @@ def available_cryptocurrencies(apikey: str) -> typing.List[typing.Dict]:
     :param apikey: Your API key.
     :return: A list of dictionaries.
     """
-    path = f"symbol/available-tsx"
+    path = f"symbol/available-cryptocurrencies"
     query_vars = {"apikey": apikey}
     return __return_json(path=path, query_vars=query_vars)
 


### PR DESCRIPTION
Change:
This change set fixes a bug in the available_cryptocurrencies function. It was pointing to the path for available stock symbols on the TSX.
Testing: 
Tested manually on my local machine. I ran black but all the changes were for code I did not change.