### PR TITLE
Add github action to run black on PRs and pushes to master

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,26 @@
+# Run black in --check mode on pull requests and pushes to master.
+# This workflow should fail on any black violations.
+name:
+
+on: [push, pull_request]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        set -xe
+        python -VV
+        python -m site
+        python -m pip install --upgrade pip
+        pip install black
+    - name: Run black
+      run: |
+        black fmpsdk --check --exclude "venv|build"


### PR DESCRIPTION
This change set adds a github action which will run black in check mode against all pull requests and pushes to master. I have another PR I will open in a moment which blackifys the __init__.py file. Everything else was good. With this action in place PRs will report status on the workflow and it can be used as a merge gate.

To see it in action:
I updated master in my fork with the workflow. This is what a PR looks like when it passes: 

https://github.com/ipl31/fmpsdk/pull/2  See the "show all checks" link.

Here are the details on the workflow execution: https://github.com/ipl31/fmpsdk/pull/2/checks?check_run_id=1933517932

Here is an example of a previous workflow on my fork that failed before I fixed the black errors: 
https://github.com/ipl31/fmpsdk/runs/1933483318

