### PR TITLE
fix issues with insider_trading function

### DIFF
--- a/fmpsdk/insider_trading.py
+++ b/fmpsdk/insider_trading.py
@@ -34,10 +34,9 @@ def insider_trading(
     path = f"insider-trading/"
     query_vars = {"apikey": apikey, "limit": limit}
     if not sum(i is not None for i in [reporting_cik, company_cik, symbol]) == 1:
-        logging.error(
-            "Do not combine symbol, reporting_cik or company_cik parameters. Only provide one."
-        )
-        exit(1)
+        msg = "Do not combine symbol, reporting_cik or company_cik parameters. Only provide one."
+        logging.error(msg)
+        raise ValueError(msg)
     if reporting_cik:
         query_vars["reportingCik"] = reporting_cik
     if company_cik:

--- a/fmpsdk/insider_trading.py
+++ b/fmpsdk/insider_trading.py
@@ -3,13 +3,15 @@ from .url_methods import (
 )
 from .settings import DEFAULT_LIMIT
 
+import logging
 import typing
 
 
 def insider_trading(
     apikey: str,
-    reporting_cik: str,
-    company_cik: str,
+    symbol: str = None,
+    reporting_cik: int = None,
+    company_cik: int = None,
     limit: int = DEFAULT_LIMIT,
 ) -> typing.List[typing.Dict]:
     """
@@ -19,7 +21,11 @@ def insider_trading(
     than 10% of any class of a company’s securities, together we’ll call, “insiders”) to report purchases, sales,
     and holdings of their company’s securities by filing Forms 3, 4, and 5.
 
+    This API can be queried with your choice of symbol, company_cik or reporting_cik. Only one of these parameters
+    will be accepted.
+
     :param apikey: Your API key.
+    :param symbol: Company ticker.
     :param reporting_cik: String of CIK
     :param company_cik: String of CIK
     :param limit: Number of records to return.
@@ -27,10 +33,17 @@ def insider_trading(
     """
     path = f"insider-trading/"
     query_vars = {"apikey": apikey, "limit": limit}
+    if not sum(i is not None for i in [reporting_cik, company_cik, symbol]) == 1:
+        logging.error(
+            "Do not combine symbol, reporting_cik or company_cik parameters. Only provide one."
+        )
+        exit(1)
     if reporting_cik:
         query_vars["reportingCik"] = reporting_cik
     if company_cik:
         query_vars["companyCik"] = company_cik
+    if symbol:
+        query_vars["symbol"] = symbol
     return __return_json_v4(path=path, query_vars=query_vars)
 
 


### PR DESCRIPTION
Tested the insider trading APIs. Insider trading RSS feed works.
Insider trading API was missing the symbol optional parameter and has another bug.

Additionally, the insider trading API call can take params of symbol, companyCik or reportingCik. But you can only provide one. Well actually you can feed the API all 3 but its only going to report data on of them and its intention is not to handle multiple params. The use cases for this are:

Symbol - Show me reported insider trades for company with symbol of X.
companyCik - Another way to query the same information. Show all insider trades of stock in the company with CIK of X. 
reportingCik - This is slightly different. This is the CIK who reported the transaction. In addition to companies, insiders can have CIKs. If you are considered an insider at a company and need to file a report when you sell stock then you will be registered with own CIK. So for example this is Tim Cook's CIK: https://sec.report/CIK/0001214156#:~:text=SEC%20CIK%20%230001214156&text=Cook%20Timothy%20D%20is%20registered%20with%20the%20U.S.%20Security%20and%20Exchange%20Commission%20.