### PR TITLE
change exit to raise ValueError

### DIFF
--- a/fmpsdk/company_valuation.py
+++ b/fmpsdk/company_valuation.py
@@ -771,8 +771,9 @@ def stock_screener(
         if type(exchange) is list:
             for item in exchange:
                 if item != __validate_exchange(item):
-                    logging.error(f"Invalid Exchange value: {exchange}.")
-                    exit(1)
+                    msg = f"Invalid Exchange value: {exchange}."
+                    logging.error(msg)
+                    raise ValueError(msg)
             query_vars["exchange"] = ",".join(exchange)
         else:
             query_vars["exchange"] = __validate_exchange(exchange)


### PR DESCRIPTION
exit is meant for CLI programs. Its not good for an API because it does not allow the caller to handle any errors, it just exits the process. Raising an exception here is the right thing to do. I picked ValueError. 