### PR TITLE
Removed the __validate_exchange method since it doesn't allow to manage all supported exchanges

### DIFF
--- a/fmpsdk/company_valuation.py
+++ b/fmpsdk/company_valuation.py
@@ -770,9 +770,9 @@ def stock_screener(
         query_vars["priceMoreThan"] = price_more_than
     if price_lower_than:
         query_vars["priceLowerThan"] = price_lower_than
-    if is_etf:
+    if is_etf is not None:
         query_vars["isEtf"] = is_etf
-    if is_actively_trading:
+    if is_actively_trading is not None:
         query_vars["isActivelyTrading"] = is_actively_trading
     if sector:
         query_vars["sector"] = __validate_sector(sector)

--- a/fmpsdk/company_valuation.py
+++ b/fmpsdk/company_valuation.py
@@ -17,7 +17,6 @@ from .settings import (
 from .url_methods import (
     __return_json_v3,
     __return_json_v4,
-    __validate_exchange,
     __validate_industry,
     __validate_period,
     __validate_sector,
@@ -74,7 +73,7 @@ def search(
         "apikey": apikey,
         "limit": limit,
         "query": query,
-        "exchange": __validate_exchange(value=exchange),
+        "exchange": exchange,
     }
     return __return_json_v3(path=path, query_vars=query_vars)
 
@@ -97,7 +96,7 @@ def search_ticker(
         "apikey": apikey,
         "limit": limit,
         "query": query,
-        "exchange": __validate_exchange(value=exchange),
+        "exchange": exchange,
     }
     return __return_json_v3(path=path, query_vars=query_vars)
 
@@ -783,14 +782,9 @@ def stock_screener(
         query_vars["country"] = country
     if exchange:
         if type(exchange) is list:
-            for item in exchange:
-                if item != __validate_exchange(item):
-                    msg = f"Invalid Exchange value: {exchange}."
-                    logging.error(msg)
-                    raise ValueError(msg)
             query_vars["exchange"] = ",".join(exchange)
         else:
-            query_vars["exchange"] = __validate_exchange(exchange)
+            query_vars["exchange"] = exchange
     return __return_json_v3(path=path, query_vars=query_vars)
 
 

--- a/fmpsdk/settings.py
+++ b/fmpsdk/settings.py
@@ -281,19 +281,6 @@ PERIOD_VALUES: typing.List = [
     "annual",
     "quarter",
 ]
-EXCHANGE_VALUES: typing.List = [
-    "ETF",
-    "MUTUAL_FUND",
-    "COMMODITY",
-    "INDEX",
-    "CRYPTO",
-    "FOREX",
-    "TSX",
-    "AMEX",
-    "NASDAQ",
-    "NYSE",
-    "EURONEXT",
-]
 TIME_DELTA_VALUES: typing.List = [
     "1min",
     "5min",

--- a/fmpsdk/stock_time_series.py
+++ b/fmpsdk/stock_time_series.py
@@ -1,7 +1,7 @@
 import typing
 
 from .general import __quotes
-from .url_methods import __return_json_v3, __return_json_v4, __validate_exchange
+from .url_methods import __return_json_v3, __return_json_v4
 
 
 def quote_short(apikey: str, symbol: str) -> typing.Optional[typing.List[typing.Dict]]:
@@ -29,7 +29,7 @@ def exchange_realtime(
     :param exchange: Exchange symbol.
     :return: A list of dictionaries.
     """
-    return __quotes(apikey=apikey, value=__validate_exchange(exchange))
+    return __quotes(apikey=apikey, value=exchange)
 
 
 def historical_stock_dividend(

--- a/fmpsdk/url_methods.py
+++ b/fmpsdk/url_methods.py
@@ -4,7 +4,6 @@ import typing
 import requests
 
 from .settings import (
-    EXCHANGE_VALUES,
     INDUSTRY_VALUES,
     PERIOD_VALUES,
     SECTOR_VALUES,
@@ -111,21 +110,6 @@ def __return_json_v4(
             f"Error: {e}"
         )
     return return_var
-
-
-def __validate_exchange(value: str) -> str:
-    """
-    Check to see if passed string is in the list of possible Exchanges.
-    :param value: Exchange name.
-    :return: Passed value or No Return
-    """
-    valid_values = EXCHANGE_VALUES
-    if value in valid_values:
-        return value
-    else:
-        logging.error(
-            f"Invalid exchange value: {value}.  Valid options: {valid_values}"
-        )
 
 
 def __validate_period(value: str) -> str:


### PR DESCRIPTION
The hard-encoded list of exchanges is too narrow.
For example the Italian stock exchange MIL is not included.
I propose to remove the __validate_exchange method completely and let the FMP api themselves manage a non-existing exchange by returning 0 results.

In addition I found a small bug in the `stock_screener` API: parameters `is_etf` and `is_actively_trading` must be checked for `None`, not for `True/False` only. Previously, for example, if you specified `is_etf=False`, it would return both ETFs and stocks.