### PR TITLE
Fix `technical_indicators` to return RSI

### DIFF
--- a/fmpsdk/settings.py
+++ b/fmpsdk/settings.py
@@ -308,7 +308,7 @@ STATISTICS_TYPE_VALUES: typing.List = [
     "dema",
     "tema",
     "williams",
-    "rsa",
+    "rsi",
     "adx",
     "standardDeviation",
 ]


### PR DESCRIPTION
This fixes a bug that made it impossible to pull the RSI technical indicator from the API since the SDK only accepted "rsa" as valid value while the API expected the value to be "rsi". 

## Steps to reproduce:

**Before this change:**
- `data = fmpsdk.technical_indicators(apikey=apikey, symbol="AAPL", statistics_type="rsi")` would complain that the only valid values are "sma", "ema", "wma", "dema", "tema", "williams", "rsa", "adx", "standardDeviation"
- `data = fmpsdk.technical_indicators(apikey=apikey, symbol="AAPL", statistics_type="rsa")` would return an empty array without an error.

**After this change:**
- `data = fmpsdk.technical_indicators(apikey=apikey, symbol="AAPL", statistics_type="rsi")` returns the correct indicators.

