### PR TITLE
Update license field to use proper SPDX identifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "20250102.0"
 description = ""
 authors = ["Dax Mickelson <github@daxm.net>"]
 readme = "README.md"
+license = "BSD-3-Clause"
 
 [tool.poetry.dependencies]
 python = "*"


### PR DESCRIPTION
This changes the license field to be a valid [SPDX identifier](https://spdx.org/licenses) aligning with [PEP 639](https://peps.python.org/pep-0639/#project-source-metadata). This populates the `license_expression` field in the PyPI API and is used by downstream tools including deps.dev

This PR was generated by Claude after reviewing the license and manifest files in your repository, but opened and reviewed by me. Please let me know if the analysis is incorrect and thanks for being an OSS maintainer.